### PR TITLE
Adds symlink to MySQL directory as well

### DIFF
--- a/rpm.pom.xml
+++ b/rpm.pom.xml
@@ -96,9 +96,18 @@
                 </source>
               </sources>
             </mapping>
-            <!-- symlink for the payload -->
+            <!-- symlink for the payload (MariaDB) -->
             <mapping>
               <directory>/usr/lib64/mariadb/plugin</directory>
+              <sources>
+                <softlinkSource>
+                  <location>/opt/teragrep/${project.artifactId}/lib/lib_mysqludf_bloom.so</location>
+                </softlinkSource>
+              </sources>
+            </mapping>
+            <!-- symlink for the payload (MySQL) -->
+            <mapping>
+              <directory>/usr/lib64/mysql/plugin</directory>
               <sources>
                 <softlinkSource>
                   <location>/opt/teragrep/${project.artifactId}/lib/lib_mysqludf_bloom.so</location>


### PR DESCRIPTION
Fixes #24

From upstream repository: 
```
MariaDB [mysql]> select name, bloommatch(name, "bloommatch") from func;
+-------------+--------------------------------+
| name        | bloommatch(name, "bloommatch") |
+-------------+--------------------------------+
| bloommatch  |                              1 |
| bloomupdate |                              0 |
+-------------+--------------------------------+
2 rows in set (0.000 sec)

MariaDB [mysql]> select version();
+----------------+
| version()      |
+----------------+
| 11.4.5-MariaDB |
+----------------+
1 row in set (0.000 sec)
```

```
# dnf info MariaDB-server
Last metadata expiration check: 0:11:15 ago on Tue May 20 11:57:36 2025.
Installed Packages
Name         : MariaDB-server
Version      : 11.4.5
Release      : 1.el8
Architecture : x86_64
Size         : 134 M
Source       : MariaDB-server-11.4.5-1.el8.src.rpm
Repository   : @System
From repo    : MariaDB-bb-11.4-release
```

```
# rpm -ql MariaDB-server | grep plugin | head -1
/usr/lib64/mysql/plugin
```


From Rocky 8 repository:
```
MariaDB [mysql]> select name, bloommatch(name, "bloommatch") from func;
+-------------+--------------------------------+
| name        | bloommatch(name, "bloommatch") |
+-------------+--------------------------------+
| bloommatch  |                              1 |
| bloomupdate |                              0 |
+-------------+--------------------------------+
2 rows in set (0.000 sec)

MariaDB [mysql]> select version();
+-----------------+
| version()       |
+-----------------+
| 10.3.39-MariaDB |
+-----------------+
1 row in set (0.000 sec)
```

```
# dnf info mariadb-server
Last metadata expiration check: 0:13:27 ago on Tue May 20 11:57:10 2025.
Installed Packages
Name         : mariadb-server
Epoch        : 3
Version      : 10.3.39
Release      : 1.module+el8.8.0+1452+2a7eab68
Architecture : x86_64
Size         : 84 M
Source       : mariadb-10.3.39-1.module+el8.8.0+1452+2a7eab68.src.rpm
Repository   : @System
From repo    : appstream
```

```
# rpm -ql mariadb-server | grep plugin | head -1
/usr/lib64/mariadb/plugin
```

The RPM itself shows the correct locations

```
# rpm -qplv blf_02.rpm  | grep plugin
lrwxrwxrwx    1 root    root                       46 May 20 11:52 /usr/lib64/mariadb/plugin/lib_mysqludf_bloom.so -> /opt/teragrep/blf_02/lib/lib_mysqludf_bloom.so
lrwxrwxrwx    1 root    root                       46 May 20 11:52 /usr/lib64/mysql/plugin/lib_mysqludf_bloom.so -> /opt/teragrep/blf_02/lib/lib_mysqludf_bloom.so
# ls -laF /opt/teragrep/blf_02/lib/lib_mysqludf_bloom.so
-rwxr-xr-x. 1 root root 8480 May 20 11:51 /opt/teragrep/blf_02/lib/lib_mysqludf_bloom.so*
```