### PR TITLE
Updates readme to show the needed packages and correct steps to build the project

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -106,16 +106,19 @@ stmt.executeUpdate();
 
 == Development
 
-MySQL client and server headers are required to compile this code.
+Compiling this project requires at least the following packages to be installed:
+
+ - `make`
+ - `automake`
+ - `autoconf`
+ - `libtool`
+ - `mariadb-devel`
 
 Please do the following in the root directory of the source tree:
 
 [source,shell]
 ----
-aclocal
-autoconf
-autoheader
-automake --add-missing
+autoreconf -fvi
 
 ./configure
 make


### PR DESCRIPTION
Fixes #23

Updates the development steps of the readme to match the Dockerfile:
https://github.com/teragrep/blf_02/blob/85fa5e885bdfc972ba8c1917ae3d4a9d4b1ab339/Dockerfile#L2
and the docker entrypoint:
https://github.com/teragrep/blf_02/blob/85fa5e885bdfc972ba8c1917ae3d4a9d4b1ab339/docker-entrypoint.sh#L3-L5